### PR TITLE
Add closed instrumentstate

### DIFF
--- a/src/Bitmex.Client.Websocket/Responses/Instruments/InstrumentState.cs
+++ b/src/Bitmex.Client.Websocket/Responses/Instruments/InstrumentState.cs
@@ -4,6 +4,7 @@
     {
         Undefined,
         Open,
-        Unlisted
+        Unlisted,
+        Closed
     }
 }


### PR DESCRIPTION
fixes the warning message: 
`Can't parse enum, value: Closed, target type: Bitmex.Client.Websocket.Responses.Instruments.InstrumentState, using default 'Undefined' 
W  Can't parse enum, value: Closed, target type: Bitmex.Client.Websocket.Responses.Instruments.InstrumentState, using default 'Undefined' `