### PR TITLE
Adds 'Rejected' order status

### DIFF
--- a/src/Bitmex.Client.Websocket/Responses/Orders/OrderStatus.cs
+++ b/src/Bitmex.Client.Websocket/Responses/Orders/OrderStatus.cs
@@ -6,6 +6,7 @@
         New,
         Filled,
         PartiallyFilled,
-        Canceled
+        Canceled,
+        Rejected
     }
 }


### PR DESCRIPTION
fixes: `Can't parse enum, value: Rejected, target type:
Bitmex.Client.Websocket.Responses.Orders.OrderStatus, using default
'Undefined'`