### PR TITLE
added fundings stream support to the client

### DIFF
--- a/src/Bitmex.Client.Websocket/Client/BitmexClientStreams.cs
+++ b/src/Bitmex.Client.Websocket/Client/BitmexClientStreams.cs
@@ -13,6 +13,7 @@ using Bitmex.Client.Websocket.Responses.Wallets;
 using Bitmex.Client.Websocket.Responses.Instruments;
 using Bitmex.Client.Websocket.Responses.Margins;
 using Bitmex.Client.Websocket.Responses.Executions;
+using Bitmex.Client.Websocket.Responses.Fundings;
 
 namespace Bitmex.Client.Websocket.Client
 {
@@ -34,6 +35,7 @@ namespace Bitmex.Client.Websocket.Client
         internal readonly Subject<QuoteResponse> QuoteSubject = new Subject<QuoteResponse>();
         internal readonly Subject<LiquidationResponse> LiquidationSubject = new Subject<LiquidationResponse>();
         internal readonly Subject<InstrumentResponse> InstrumentSubject = new Subject<InstrumentResponse>();
+        internal readonly Subject<FundingResponse> FundingsSubject = new Subject<FundingResponse>();
 
         internal readonly Subject<WalletResponse> WalletSubject = new Subject<WalletResponse>();
         internal readonly Subject<OrderResponse> OrderSubject = new Subject<OrderResponse>();
@@ -93,6 +95,12 @@ namespace Bitmex.Client.Websocket.Client
         /// Stream of all Trade-able Contracts, Indices, and History
         /// </summary>
         public IObservable<InstrumentResponse> InstrumentStream => InstrumentSubject.AsObservable();
+
+        /// <summary>
+        /// Fundings stream - updates of swap funding rates. Sent every funding interval (usually 8hrs) 
+        /// <para>!!! Any time you connect to the stream, you receive the latest active funding rate</para>
+        /// </summary>
+        public IObservable<FundingResponse> FundingStream => FundingsSubject.AsObservable();
 
 
 

--- a/src/Bitmex.Client.Websocket/Client/BitmexWebsocketClient.cs
+++ b/src/Bitmex.Client.Websocket/Client/BitmexWebsocketClient.cs
@@ -19,6 +19,7 @@ using Bitmex.Client.Websocket.Responses.Instruments;
 using Bitmex.Client.Websocket.Responses.Margins;
 using Websocket.Client;
 using Bitmex.Client.Websocket.Responses.Executions;
+using Bitmex.Client.Websocket.Responses.Fundings;
 
 namespace Bitmex.Client.Websocket.Client
 {
@@ -151,7 +152,7 @@ namespace Bitmex.Client.Websocket.Client
                 WalletResponse.TryHandle(response, Streams.WalletSubject) ||
                 InstrumentResponse.TryHandle(response, Streams.InstrumentSubject) ||
                 ExecutionResponse.TryHandle(response, Streams.ExecutionSubject) ||
-
+                FundingResponse.TryHandle(response, Streams.FundingsSubject) ||
 
                 ErrorResponse.TryHandle(response, Streams.ErrorSubject) ||
                 SubscribeResponse.TryHandle(response, Streams.SubscribeSubject) ||

--- a/src/Bitmex.Client.Websocket/Messages/MessageType.cs
+++ b/src/Bitmex.Client.Websocket/Messages/MessageType.cs
@@ -21,5 +21,6 @@
         Instrument,
         Margin,
         Execution,
+        Funding
     }
 }

--- a/src/Bitmex.Client.Websocket/Requests/FundingsSubscribeRequest.cs
+++ b/src/Bitmex.Client.Websocket/Requests/FundingsSubscribeRequest.cs
@@ -1,0 +1,35 @@
+﻿using Bitmex.Client.Websocket.Validations;
+
+namespace Bitmex.Client.Websocket.Requests
+{
+    /// <summary>
+    /// Subscribe to trades stream
+    /// </summary>
+    public class FundingsSubscribeRequest : SubscribeRequestBase
+    {
+        /// <summary>
+        /// Subscribe to all fundings
+        /// </summary>
+        public FundingsSubscribeRequest()
+        {
+            Symbol = string.Empty;
+        }
+
+        /// <summary>
+        /// Subscribe to fundings for selected pair, e.g. 'XBTUSD'
+        /// </summary>
+        public FundingsSubscribeRequest(string pair)
+        {
+            BmxValidations.ValidateInput(pair, nameof(pair));
+            Symbol = pair;
+        }
+
+        /// <summary>
+        /// Funding topic
+        /// </summary>
+        public override string Topic => "funding";
+
+        /// <inheritdoc />
+        public override string Symbol { get; }
+    }
+}

--- a/src/Bitmex.Client.Websocket/Responses/Fundings/Funding.cs
+++ b/src/Bitmex.Client.Websocket/Responses/Fundings/Funding.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Bitmex.Client.Websocket.Responses.Fundings
+{
+    public class Funding
+    {
+        public DateTime Timestamp { get; set; }
+
+        public string Symbol { get; set; }
+
+        public DateTime FundingInterval { get; set; }
+
+        public double FundingRate { get; set; }
+
+        public double FundingRateDaily { get; set; }
+    }
+}

--- a/src/Bitmex.Client.Websocket/Responses/Fundings/FundingResponse.cs
+++ b/src/Bitmex.Client.Websocket/Responses/Fundings/FundingResponse.cs
@@ -1,0 +1,34 @@
+﻿using System.Reactive.Subjects;
+using Bitmex.Client.Websocket.Json;
+using Bitmex.Client.Websocket.Messages;
+using Newtonsoft.Json.Linq;
+
+namespace Bitmex.Client.Websocket.Responses.Fundings
+{
+    /// <summary>
+    /// Fundings response
+    /// </summary>
+    public class FundingResponse : ResponseBase
+    {
+        /// <summary>
+        /// Operation type
+        /// </summary>
+        public override MessageType Op => MessageType.Funding;
+
+        /// <summary>
+        /// All latest fundings
+        /// </summary>
+        public Funding[] Data { get; set; }
+
+        internal static bool TryHandle(JObject response, ISubject<FundingResponse> subject)
+        {
+            if (response?["table"]?.Value<string>() != "funding")
+                return false;
+
+            var parsed = response.ToObject<FundingResponse>(BitmexJsonSerializer.Serializer);
+            subject.OnNext(parsed);
+
+            return true;
+        }
+    }
+}

--- a/test_integration/Bitmex.Client.Websocket.Sample/Program.cs
+++ b/test_integration/Bitmex.Client.Websocket.Sample/Program.cs
@@ -80,6 +80,7 @@ namespace Bitmex.Client.Websocket.Sample
             await client.Send(new QuoteSubscribeRequest("XBTUSD"));
             //await client.Send(new LiquidationSubscribeRequest());
             //await client.Send(new InstrumentSubscribeRequest("XBTUSD"));
+            //await client.Send(new FundingsSubscribeRequest("XBTUSD"));
 
             if (!string.IsNullOrWhiteSpace(API_SECRET))
                 await client.Send(new AuthenticationRequest(API_KEY, API_SECRET));
@@ -131,7 +132,7 @@ namespace Bitmex.Client.Websocket.Sample
 
             client.Streams.TradesStream.Subscribe(y =>
                 y.Data.ToList().ForEach(x =>
-                    Log.Information($"Trade {x.Symbol} executed. Time: {x.Timestamp:mm:ss.fff}, [{x.Side}] Amount: {x.Size}, " +
+                    Log.Information($"Trade {x.Symbol} executed. Time: {x.Timestamp:HH:mm:ss.fff}, [{x.Side}] Amount: {x.Size}, " +
                                     $"Price: {x.Price}"))
             );
 
@@ -165,6 +166,15 @@ namespace Bitmex.Client.Websocket.Sample
                                     $"price: {y.MarkPrice}, last: {y.LastPrice}, " +
                                     $"mark: {y.MarkMethod}, fair: {y.FairMethod}, direction: {y.LastTickDirection}, " +
                                     $"funding: {y.FundingRate} i: {y.IndicativeFundingRate} s: {y.FundingQuoteSymbol}");
+                });
+            });
+
+            client.Streams.FundingStream.Subscribe(x =>
+            {
+                x.Data.ToList().ForEach(f =>
+                {
+                    Log.Information($"Funding {f.Symbol}, Timestamp: {f.Timestamp}, Interval: {f.FundingInterval}, " +
+                                    $"Rate: {f.FundingRate}, RateDaily: {f.FundingRateDaily}");
                 });
             });
 


### PR DESCRIPTION
I've tested the functionality within Bitmex.Client.Websocket.Sample console app. I tried it when the new funding should have been received (at the end of 8h funding interval) and everything worked as expected.