### PR TITLE
Recorder

### DIFF
--- a/Bitmex.Client.Websocket.sln
+++ b/Bitmex.Client.Websocket.sln
@@ -24,6 +24,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bitmex.Client.Websocket.Recorder.Sample", "test_integration\Bitmex.Client.Websocket.Recorder.Sample\Bitmex.Client.Websocket.Recorder.Sample.csproj", "{953D7893-B3F5-4C52-9100-60F6B9E3A47E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -46,6 +48,10 @@ Global
 		{7B649867-E540-4592-A821-8EB06BFB01C6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7B649867-E540-4592-A821-8EB06BFB01C6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7B649867-E540-4592-A821-8EB06BFB01C6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{953D7893-B3F5-4C52-9100-60F6B9E3A47E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{953D7893-B3F5-4C52-9100-60F6B9E3A47E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{953D7893-B3F5-4C52-9100-60F6B9E3A47E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{953D7893-B3F5-4C52-9100-60F6B9E3A47E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -55,6 +61,7 @@ Global
 		{DB710400-5C51-41B4-A705-186631C99ED0} = {0544BC01-B569-4729-86B0-5AFDBF7EED46}
 		{120B8005-7858-4D04-A11B-ACCFFACAC91B} = {42E4078C-4FBE-4B03-B889-1573332945A9}
 		{7B649867-E540-4592-A821-8EB06BFB01C6} = {42E4078C-4FBE-4B03-B889-1573332945A9}
+		{953D7893-B3F5-4C52-9100-60F6B9E3A47E} = {42E4078C-4FBE-4B03-B889-1573332945A9}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {EE3E0B94-CF20-4C22-B50B-E720E8DFD675}

--- a/src/Bitmex.Client.Websocket/Client/BitmexWebsocketClient.cs
+++ b/src/Bitmex.Client.Websocket/Client/BitmexWebsocketClient.cs
@@ -97,7 +97,7 @@ namespace Bitmex.Client.Websocket.Client
             return $"[BMX WEBSOCKET CLIENT] {msg}";
         }
 
-        private void HandleMessage(ResponseMessage message)
+        protected virtual void HandleMessage(ResponseMessage message)
         {
             try
             {

--- a/src/Bitmex.Client.Websocket/Recorder/BitmexWebsocketRecorderClient.cs
+++ b/src/Bitmex.Client.Websocket/Recorder/BitmexWebsocketRecorderClient.cs
@@ -14,6 +14,11 @@ namespace Bitmex.Client.Websocket.Recorder
         private readonly UnicodeEncoding _uniEncoding = new UnicodeEncoding();
 
         /// <summary>
+        /// Whether the recorder is currently writing to disk. Used to avoid interupting int he middle of a record.
+        /// </summary>
+        public bool IsWriting { get; private set; } = false;
+
+        /// <summary>
         /// A BitmexWebsocketClient which records the raw data comming off the websocket
         /// </summary>
         /// <param name="communicator"></param>
@@ -29,7 +34,9 @@ namespace Bitmex.Client.Websocket.Recorder
         protected override void HandleMessage(ResponseMessage message)
         {
             var tempString = message + _delimiter;
+            IsWriting = true;
             _recording.Write(_uniEncoding.GetBytes(tempString), 0, _uniEncoding.GetByteCount(tempString));
+            IsWriting = false;
             base.HandleMessage(message);
         }
     }

--- a/src/Bitmex.Client.Websocket/Recorder/BitmexWebsocketRecorderClient.cs
+++ b/src/Bitmex.Client.Websocket/Recorder/BitmexWebsocketRecorderClient.cs
@@ -26,14 +26,21 @@ namespace Bitmex.Client.Websocket.Recorder
         /// A BitmexWebsocketClient which records the raw data comming off the websocket
         /// </summary>
         /// <param name="communicator"></param>
-        /// <param name="recordingPath">Recording file pathname. Overwritten if it exists.</param>
+        /// <param name="recordingPath">Recording file pathname. Overwritten if it exists. If null recording is disabled.</param>
         /// <param name="delimiter">Separator inserted between records.</param>
-        public BitmexWebsocketRecorderClient(IBitmexCommunicator communicator, string recordingPath, string delimiter = ";;")
+        public BitmexWebsocketRecorderClient(IBitmexCommunicator communicator, string recordingPath = null, string delimiter = ";;")
             : base(communicator)
         {
-            _recordingStream = File.Create(recordingPath);
-            _recorder = new StreamWriter(_recordingStream);
-            _delimiter = delimiter;
+            if (recordingPath == null)
+            {
+                _stopped = true;
+            }
+            else
+            {
+                _recordingStream = File.Create(recordingPath);
+                _recorder = new StreamWriter(_recordingStream);
+                _delimiter = delimiter;
+            }
         }
 
         /// <summary>
@@ -65,7 +72,6 @@ namespace Bitmex.Client.Websocket.Recorder
             {
                 if (!_stopped)
                     _recorder.Write(tempString);
-                    //_recording.Write(_uniEncoding.GetBytes(tempString), 0, _uniEncoding.GetByteCount(tempString));
             }
             base.HandleMessage(message);
         }

--- a/src/Bitmex.Client.Websocket/Recorder/BitmexWebsocketRecorderClient.cs
+++ b/src/Bitmex.Client.Websocket/Recorder/BitmexWebsocketRecorderClient.cs
@@ -1,0 +1,36 @@
+﻿using Bitmex.Client.Websocket.Client;
+using Bitmex.Client.Websocket.Communicator;
+using System;
+using System.IO;
+using System.Text;
+using Websocket.Client;
+
+namespace Bitmex.Client.Websocket.Recorder
+{
+    public class BitmexWebsocketRecorderClient : BitmexWebsocketClient
+    {
+        private readonly FileStream _recording;
+        private readonly string _delimiter;
+        private readonly UnicodeEncoding _uniEncoding = new UnicodeEncoding();
+
+        /// <summary>
+        /// A BitmexWebsocketClient which records the raw data comming off the websocket
+        /// </summary>
+        /// <param name="communicator"></param>
+        /// <param name="recordingPath">Recording file pathname. Overwritten if it exists.</param>
+        /// <param name="delimiter">Separator inserted between records.</param>
+        public BitmexWebsocketRecorderClient(IBitmexCommunicator communicator, string recordingPath, string delimiter = ";;")
+            : base(communicator)
+        {
+            _recording = File.Create(recordingPath);
+            _delimiter = delimiter;
+        }
+
+        protected override void HandleMessage(ResponseMessage message)
+        {
+            var tempString = message + _delimiter;
+            _recording.Write(_uniEncoding.GetBytes(tempString), 0, _uniEncoding.GetByteCount(tempString));
+            base.HandleMessage(message);
+        }
+    }
+}

--- a/test_integration/Bitmex.Client.Websocket.Recorder.Sample/Bitmex.Client.Websocket.Recorder.Sample.csproj
+++ b/test_integration/Bitmex.Client.Websocket.Recorder.Sample/Bitmex.Client.Websocket.Recorder.Sample.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Bitmex.Client.Websocket\Bitmex.Client.Websocket.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="data\" />
+  </ItemGroup>
+
+</Project>

--- a/test_integration/Bitmex.Client.Websocket.Recorder.Sample/Program.cs
+++ b/test_integration/Bitmex.Client.Websocket.Recorder.Sample/Program.cs
@@ -1,0 +1,247 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Threading;
+using System.Threading.Tasks;
+using Bitmex.Client.Websocket.Recorder;
+using Bitmex.Client.Websocket.Requests;
+using Bitmex.Client.Websocket.Websockets;
+using Serilog;
+using Serilog.Events;
+
+namespace Bitmex.Client.Websocket.Recorder.Sample
+{
+    class Program
+    {
+        private static readonly ManualResetEvent ExitEvent = new ManualResetEvent(false);
+        private static readonly string RecordingFile = "data/bitmex_raw_xbtusd.txt";
+
+        //private static  readonly string baseDir = AppDomain.CurrentDomain.BaseDirectory;
+        //private static readonly string workingDir = Environment.CurrentDirectory;
+        private static readonly string ProjectDirectory = Directory.GetParent(Environment.CurrentDirectory).Parent.Parent.FullName;
+
+        private static readonly string API_KEY = "your_api_key";
+        private static readonly string API_SECRET = "";
+
+        static void Main(string[] args)
+        {
+            InitLogging();
+
+            AppDomain.CurrentDomain.ProcessExit += CurrentDomainOnProcessExit;
+            AssemblyLoadContext.Default.Unloading += DefaultOnUnloading;
+ 
+            Console.WriteLine("|=======================|");
+            Console.WriteLine("|     BITMEX CLIENT     |");
+            Console.WriteLine("|=======================|");
+            Console.WriteLine();
+
+            Log.Debug("====================================");
+            Log.Debug("              STARTING              ");
+            Log.Debug("====================================");
+
+
+
+            var url = BitmexValues.ApiWebsocketUrl;
+            using (var communicator = new BitmexWebsocketCommunicator(url))
+            {
+                communicator.Name = "Bitmex-1";
+                communicator.ReconnectTimeout = TimeSpan.FromMinutes(10);
+                communicator.ReconnectionHappened.Subscribe(type =>
+                    Log.Information($"Reconnection happened, type: {type.Type}"));
+
+                var recordingPath = Path.Combine(ProjectDirectory, RecordingFile);
+                using (var client = new BitmexWebsocketRecorderClient(communicator, recordingPath, delimiter: ";;"))
+                {
+                    Console.CancelKeyPress += (sender, e) => ConsoleOnCancelKeyPress(sender, e, client);
+
+                    client.Streams.InfoStream.Subscribe(info =>
+                    {
+                        Log.Information($"Reconnection happened, Message: {info.Info}, Version: {info.Version:D}");
+                        SendSubscriptionRequests(client).Wait();
+                    });
+
+                    SubscribeToStreams(client);
+
+                    communicator.Start();
+
+                    _ = StartPinging(client);
+
+                    ExitEvent.WaitOne();
+                }
+            }
+
+            Log.Debug("====================================");
+            Log.Debug("              STOPPING              ");
+            Log.Debug("====================================");
+            Log.CloseAndFlush();
+        }
+
+        private static async Task StartPinging(BitmexWebsocketRecorderClient client)
+        {
+            await Task.Delay(TimeSpan.FromSeconds(30));
+            client.Send(new PingRequest());
+        }
+
+        private static async Task SendSubscriptionRequests(BitmexWebsocketRecorderClient client)
+        {
+            client.Send(new PingRequest());
+            //client.Send(new BookSubscribeRequest("XBTUSD"));
+            client.Send(new TradesSubscribeRequest("XBTUSD"));
+            //client.Send(new TradeBinSubscribeRequest("1m", "XBTUSD"));
+            //client.Send(new TradeBinSubscribeRequest("5m", "XBTUSD"));
+            client.Send(new QuoteSubscribeRequest("XBTUSD"));
+            client.Send(new LiquidationSubscribeRequest());
+            client.Send(new InstrumentSubscribeRequest("XBTUSD"));
+            client.Send(new FundingsSubscribeRequest("XBTUSD"));
+            //client.Send(new Book25SubscribeRequest("XBTUSD"));
+            //client.Send(new Book10SubscribeRequest("XBTUSD"));
+
+            if (!string.IsNullOrWhiteSpace(API_SECRET))
+                client.Send(new AuthenticationRequest(API_KEY, API_SECRET));
+        }
+
+        private static void SubscribeToStreams(BitmexWebsocketRecorderClient client)
+        {
+            client.Streams.ErrorStream.Subscribe(x =>
+                Log.Warning($"Error received, message: {x.Error}, status: {x.Status}"));
+
+            client.Streams.AuthenticationStream.Subscribe(x =>
+            {
+                Log.Information($"Authentication happened, success: {x.Success}");
+                client.Send(new WalletSubscribeRequest());
+                client.Send(new OrderSubscribeRequest());
+                client.Send(new PositionSubscribeRequest());
+            });
+
+
+            client.Streams.SubscribeStream.Subscribe(x =>
+            {
+                Log.Information(x.IsSubscription
+                    ? $"Subscribed ({x.Success}) to {x.Subscribe}"
+                    : $"Unsubscribed ({x.Success}) from {x.Unsubscribe}");
+            });
+
+            client.Streams.PongStream.Subscribe(x =>
+                Log.Information($"Pong received ({x.Message})"));
+
+
+            client.Streams.WalletStream.Subscribe(y =>
+                y.Data.ToList().ForEach(x =>
+                    Log.Information($"Wallet {x.Account}, {x.Currency} amount: {x.BalanceBtc}"))
+            );
+
+            client.Streams.OrderStream.Subscribe(y =>
+                y.Data.ToList().ForEach(x =>
+                    Log.Information(
+                        $"Order {x.Symbol} {x.OrderId} updated. Time: {x.Timestamp:HH:mm:ss.fff}, Amount: {x.OrderQty}, " +
+                        $"Price: {x.Price}, Direction: {x.Side}, Working: {x.WorkingIndicator}, Status: {x.OrdStatus}"))
+            );
+
+            client.Streams.PositionStream.Subscribe(y =>
+                y.Data.ToList().ForEach(x =>
+                    Log.Information(
+                        $"Position {x.Symbol}, {x.Currency} updated. Time: {x.Timestamp:HH:mm:ss.fff}, Amount: {x.CurrentQty}, " +
+                        $"Entry: {x.AvgEntryPrice}, Price: {x.LastPrice}, Liq: {x.LiquidationPrice}, " +
+                        $"PNL: {x.UnrealisedPnl}"))
+            );
+
+            client.Streams.TradesStream.Subscribe(y =>
+                y.Data.ToList().ForEach(x =>
+                    Log.Information($"Trade {x.Symbol} executed. Time: {x.Timestamp:HH:mm:ss.fff}, [{x.Side}] Amount: {x.Size}, " +
+                                    $"Price: {x.Price}, Match: {x.TrdMatchId}"))
+            );
+
+            client.Streams.BookStream.Subscribe(book =>
+                book.Data.Take(100).ToList().ForEach(x => Log.Information(
+                    $"Book | {book.Action} pair: {x.Symbol}, price: {x.Price}, amount {x.Size}, side: {x.Side}"))
+            );
+
+            client.Streams.Book25Stream.Subscribe(book =>
+                book.Data.Take(100).ToList().ForEach(x => Log.Information(
+                    $"Book | {book.Action} pair: {x.Symbol}, price: {x.Price}, amount {x.Size}, side: {x.Side}"))
+            );
+
+            client.Streams.QuoteStream.Subscribe(y =>
+                y.Data.ToList().ForEach(x =>
+                    Log.Information($"Quote {x.Symbol}. Bid: {x.BidPrice} - {x.BidSize} Ask: {x.AskPrice} - {x.AskSize}"))
+            );
+
+            client.Streams.LiquidationStream.Subscribe(y =>
+                y.Data.ToList().ForEach(x =>
+                    Log.Information(
+                        $"Liquidation Action: {y.Action}, OrderID: {x.OrderID}, Symbol: {x.Symbol}, Side: {x.Side}, Price: {x.Price}, LeavesQty: {x.leavesQty}"))
+            );
+
+            client.Streams.TradeBinStream.Subscribe(y =>
+                y.Data.ToList().ForEach(x =>
+                Log.Information($"TradeBin table:{y.Table} {x.Symbol} executed. Time: {x.Timestamp:mm:ss.fff}, Open: {x.Open}, " +
+                        $"Close: {x.Close}, Volume: {x.Volume}, Trades: {x.Trades}"))
+            );
+
+            client.Streams.InstrumentStream.Subscribe(x =>
+            {
+                x.Data.ToList().ForEach(y =>
+                {
+                    Log.Information($"Instrument, {y.Symbol}, " +
+                                    $"price: {y.MarkPrice}, last: {y.LastPrice}, " +
+                                    $"mark: {y.MarkMethod}, fair: {y.FairMethod}, direction: {y.LastTickDirection}, " +
+                                    $"funding: {y.FundingRate} i: {y.IndicativeFundingRate} s: {y.FundingQuoteSymbol}");
+                });
+            });
+
+            client.Streams.FundingStream.Subscribe(x =>
+            {
+                x.Data.ToList().ForEach(f =>
+                {
+                    Log.Information($"Funding {f.Symbol}, Timestamp: {f.Timestamp}, Interval: {f.FundingInterval}, " +
+                                    $"Rate: {f.FundingRate}, RateDaily: {f.FundingRateDaily}");
+                });
+            });
+
+
+            // example of unsubscribe requests
+            //Task.Run(async () =>
+            //{
+            //    await Task.Delay(5000);
+            //    client.Send(new BookSubscribeRequest("XBTUSD") { IsUnsubscribe = true });
+            //    await Task.Delay(5000);
+            //    client.Send(new TradesSubscribeRequest() { IsUnsubscribe = true });
+            //});
+        }
+
+        private static void InitLogging()
+        {
+            var executingDir = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
+            var logPath = Path.Combine(executingDir, "logs", "verbose.log");
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .WriteTo.File(logPath, rollingInterval: RollingInterval.Day)
+                .WriteTo.ColoredConsole(LogEventLevel.Information)
+                .CreateLogger();
+        }
+
+        private static void CurrentDomainOnProcessExit(object sender, EventArgs eventArgs)
+        {
+            Log.Warning("Exiting process");
+            ExitEvent.Set();
+        }
+
+        private static void DefaultOnUnloading(AssemblyLoadContext assemblyLoadContext)
+        {
+            Log.Warning("Unloading process");
+            ExitEvent.Set();
+        }
+
+        private static void ConsoleOnCancelKeyPress(object sender, ConsoleCancelEventArgs e, BitmexWebsocketRecorderClient client)
+        {
+            Log.Warning("Attempting to cancel process");
+            e.Cancel = true;
+            if (client.IsWriting) 
+                Log.Warning("Cannot interrupt disk write. Please try again.");
+            else
+                ExitEvent.Set();
+        }
+    }
+}

--- a/test_integration/Bitmex.Client.Websocket.Recorder.Sample/Program.cs
+++ b/test_integration/Bitmex.Client.Websocket.Recorder.Sample/Program.cs
@@ -18,8 +18,6 @@ namespace Bitmex.Client.Websocket.Recorder.Sample
         private static readonly ManualResetEvent ExitEvent = new ManualResetEvent(false);
         private static readonly string RecordingFile = "data/bitmex_raw_xbtusd.txt";
 
-        //private static  readonly string baseDir = AppDomain.CurrentDomain.BaseDirectory;
-        //private static readonly string workingDir = Environment.CurrentDirectory;
         private static readonly string ProjectDirectory = Directory.GetParent(Environment.CurrentDirectory).Parent.Parent.FullName;
 
         private static readonly string API_KEY = "your_api_key";
@@ -41,7 +39,6 @@ namespace Bitmex.Client.Websocket.Recorder.Sample
             Log.Debug("====================================");
             Log.Debug("              STARTING              ");
             Log.Debug("====================================");
-
 
 
             var url = BitmexValues.ApiWebsocketUrl;


### PR DESCRIPTION
Added the class BitmexWebsocketRecorderClient. It extends the BitmexWebsocketClient class to have the ability to save *all* of the output of the websocket to a file that can be played back through the BitmexFileCommunicator.

This could have alternatively been added to the websocket client instead, but in case it has potential future need for specific BitMEX related control it is better here.